### PR TITLE
Fix edition API base URL

### DIFF
--- a/src/app/edition/edition-api.ts
+++ b/src/app/edition/edition-api.ts
@@ -19,7 +19,10 @@ export interface EditionDto {
   providedIn: 'root'
 })
 export class EditionApi {
-  private baseUrl = '/api/rest/v1/edition';
+  // Base URL of the edition API on the backend server.
+  // Using the absolute address avoids 404 errors when the
+  // Angular dev server runs on a different port (e.g. 4200).
+  private baseUrl = 'http://localhost:8080/api/rest/v1/edition';
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
## Summary
- update edition API base URL to point to backend on port 8080

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d95b8fd0c832f98162661e8a11586