### PR TITLE
Configure environments and proxy for CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,23 @@ construída em [Angular](https://angular.dev) na versão estável mais recente.
    ```bash
    npm install
    ```
-2. Inicie o servidor de desenvolvimento:
+2. Inicie o servidor de desenvolvimento. A configuração `proxy.conf.json`
+   redireciona as chamadas para `/api` ao backend em `http://localhost:8080`,
+   evitando problemas de CORS:
    ```bash
    npm start
    # ou use npx ng serve
    ```
    Após iniciar, acesse `http://localhost:4200/` no navegador. O recarregamento
    automático ocorrerá a cada modificação nos arquivos fonte.
+
+## Configuração de domínios por ambiente
+
+Os domínios utilizados para as chamadas de API ficam em `src/environments/`.
+Existem arquivos separados para **desenvolvimento**, **homologação** e
+**produção** (`environment.ts`, `environment.hml.ts` e `environment.prod.ts`).
+Durante o build, o Angular substitui o arquivo correto conforme a configuração
+escolhida.
 
 ## Geração de código
 

--- a/angular.json
+++ b/angular.json
@@ -42,24 +42,53 @@
                   "maximumError": "8kB"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ]
             },
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.ts"
+                }
+              ]
+            },
+            "hml": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.hml.ts"
+                }
+              ]
             }
           },
           "defaultConfiguration": "production"
         },
         "serve": {
           "builder": "@angular/build:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "buildTarget": "jogosfenaefrontend:build:production"
             },
             "development": {
               "buildTarget": "jogosfenaefrontend:build:development"
+            },
+            "hml": {
+              "buildTarget": "jogosfenaefrontend:build:hml"
             }
           },
           "defaultConfiguration": "development"

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,0 +1,8 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}

--- a/src/app/edition/edition-api.ts
+++ b/src/app/edition/edition-api.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
 
 export interface EditionDto {
   id?: number;
@@ -20,9 +21,9 @@ export interface EditionDto {
 })
 export class EditionApi {
   // Base URL of the edition API on the backend server.
-  // Using the absolute address avoids 404 errors when the
-  // Angular dev server runs on a different port (e.g. 4200).
-  private baseUrl = 'http://localhost:8080/api/rest/v1/edition';
+  // Loaded from the environment configuration to support
+  // different domains for development, homologation and production.
+  private baseUrl = `${environment.apiBaseUrl}/api/rest/v1/edition`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/environments/environment.hml.ts
+++ b/src/environments/environment.hml.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'https://hml.example.com'
+};

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiBaseUrl: 'https://api.example.com'
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://localhost:8080'
+};


### PR DESCRIPTION
## Summary
- centralize API base URLs under `src/environments`
- load base URL from environment in edition API
- add `proxy.conf.json` for dev server CORS bypass
- configure build/serve targets for dev, hml and prod
- document new setup in README

## Testing
- `npm test` *(fails: No binary for Chrome)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d979227c0832fa4957382e7fcd81e