### PR TITLE
Fix CORS issues by using Angular proxy URL

### DIFF
--- a/src/app/edition/edition-api.ts
+++ b/src/app/edition/edition-api.ts
@@ -20,10 +20,10 @@ export interface EditionDto {
   providedIn: 'root'
 })
 export class EditionApi {
-  // Base URL of the edition API on the backend server.
-  // Loaded from the environment configuration to support
-  // different domains for development, homologation and production.
-  private baseUrl = `${environment.apiBaseUrl}/api/rest/v1/edition`;
+  // Base URL of the edition API. The `apiBaseUrl` already contains the `/api`
+  // prefix for all environments, including development where the Angular
+  // dev-server proxy forwards requests to the backend.
+  private baseUrl = `${environment.apiBaseUrl}/rest/v1/edition`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/environments/environment.hml.ts
+++ b/src/environments/environment.hml.ts
@@ -1,4 +1,6 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'https://hml.example.com'
+  // Base URL of the homologation API. Includes `/api` so the same code
+  // generates requests like `https://hml.example.com/api/rest/v1/...`.
+  apiBaseUrl: 'https://hml.example.com/api'
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,6 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'https://api.example.com'
+  // Base URL for the production API. `/api` is included to keep the same
+  // request paths used in development and homologation environments.
+  apiBaseUrl: 'https://api.example.com/api'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,7 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:8080'
+  // Use the Angular dev-server proxy. All HTTP calls to `/api` will be
+  // forwarded to the backend running on http://localhost:8080, avoiding CORS
+  // issues during local development.
+  apiBaseUrl: '/api'
 };


### PR DESCRIPTION
## Summary
- configure development environment to use `/api` so requests pass through the Angular proxy
- update homologation and production URLs to include `/api`
- adjust `EditionApi` to append only the REST path

## Testing
- `npm install`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_684d9a84d914832f830683c2ee57c009