### PR TITLE
Fix CORS issue by using proxy in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ construída em [Angular](https://angular.dev) na versão estável mais recente.
    ```
    Após iniciar, acesse `http://localhost:4200/` no navegador. O recarregamento
    automático ocorrerá a cada modificação nos arquivos fonte.
+3. O arquivo `src/environments/environment.ts` define `apiBaseUrl` como
+   `/api`. Isso garante que as requisições passem pelo proxy do Angular,
+   evitando problemas de CORS durante o desenvolvimento.
 
 ## Configuração de domínios por ambiente
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,6 +2,7 @@ export const environment = {
   production: false,
   // Use the Angular dev-server proxy. All HTTP calls to `/api` will be
   // forwarded to the backend running on http://localhost:8080, avoiding CORS
-  // issues during local development.
-  apiBaseUrl: 'http://localhost:8080/api'
+  // issues during local development. Keep the base URL relative so the
+  // development server can intercept requests and proxy them correctly.
+  apiBaseUrl: '/api'
 };


### PR DESCRIPTION
## Summary
- use relative URL for `apiBaseUrl` so Angular dev-server proxy handles requests
- mention the proxy setup in README

## Testing
- `npm install`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684da0ad5410832faf0e416fec576a77