### PR TITLE
Fix missing pt-BR locale

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, LOCALE_ID, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 
@@ -9,6 +9,7 @@ export const appConfig: ApplicationConfig = {
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient()
+    provideHttpClient(),
+    { provide: LOCALE_ID, useValue: 'pt-BR' }
   ]
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
 import { bootstrapApplication } from '@angular/platform-browser';
+import { registerLocaleData } from '@angular/common';
+import localePt from '@angular/common/locales/pt';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
+
+registerLocaleData(localePt, 'pt-BR');
 
 bootstrapApplication(App, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- configure Angular to use the `pt-BR` locale
- register locale data before bootstrapping

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_684da732ef0c832fa1d5b1a63de67a9a