### PR TITLE
Improve Material dialog styles

### DIFF
--- a/src/app/edition/edition-form-dialog.css
+++ b/src/app/edition/edition-form-dialog.css
@@ -19,3 +19,10 @@
   gap: 0.5rem;
   margin-top: 1rem;
 }
+
+.ckeditor-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.75rem;
+  color: rgba(0, 0, 0, 0.6);
+}

--- a/src/app/edition/edition-form-dialog.html
+++ b/src/app/edition/edition-form-dialog.html
@@ -1,8 +1,10 @@
+<h2 mat-dialog-title>{{ data.edition ? 'Editar Edição' : 'Nova Edição' }}</h2>
 <form [formGroup]="form" class="dialog-form" (ngSubmit)="save()">
-  <mat-form-field appearance="fill" class="full-width">
-    <mat-label>Título</mat-label>
-    <input matInput formControlName="title" />
-  </mat-form-field>
+  <div mat-dialog-content>
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Título</mat-label>
+      <input matInput formControlName="title" />
+    </mat-form-field>
 
   <div class="row">
     <mat-form-field appearance="fill">
@@ -41,10 +43,10 @@
     </mat-form-field>
   </div>
 
-  <mat-form-field appearance="fill" class="full-width">
-    <mat-label>Descrição</mat-label>
-    <ckeditor formControlName="description"></ckeditor>
-  </mat-form-field>
+    <div class="full-width">
+      <label class="ckeditor-label">Descrição</label>
+      <ckeditor formControlName="description"></ckeditor>
+    </div>
 
   <div class="row">
     <mat-form-field appearance="fill" class="flex">
@@ -54,7 +56,8 @@
     <mat-checkbox formControlName="currentEdition">Atual</mat-checkbox>
   </div>
 
-  <div class="actions">
+  </div>
+  <div mat-dialog-actions align="end" class="actions">
     <button mat-raised-button color="primary" type="submit">Salvar</button>
     <button mat-button type="button" (click)="cancel()">Cancelar</button>
   </div>

--- a/src/app/edition/edition-form-dialog.ts
+++ b/src/app/edition/edition-form-dialog.ts
@@ -23,7 +23,7 @@ import { EditionDto } from './edition-api';
     CKEditorModule
   ],
   templateUrl: './edition-form-dialog.html',
-  styleUrl: './edition-form-dialog.css'
+  styleUrls: ['./edition-form-dialog.css']
 })
 export class EditionFormDialogComponent {
   form: FormGroup;

--- a/src/app/edition/edition.ts
+++ b/src/app/edition/edition.ts
@@ -21,7 +21,7 @@ import { EditionApi, EditionDto } from './edition-api';
     EditionFormDialogComponent
   ],
   templateUrl: './edition.html',
-  styleUrl: './edition.css'
+  styleUrls: ['./edition.css']
 })
 export class EditionComponent implements OnInit {
   editions: EditionDto[] = [];


### PR DESCRIPTION
## Summary
- reference styleUrls correctly for Edition components
- style the Edition form dialog using Angular Material dialog structure
- tweak dialog CSS for CKEditor label

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de3f7649c832f871bf36c81a65ed6