### PR TITLE
Add validation for required fields in Edition form

### DIFF
--- a/src/app/edition/edition-form-dialog.html
+++ b/src/app/edition/edition-form-dialog.html
@@ -4,20 +4,35 @@
     <mat-form-field appearance="fill" class="full-width">
       <mat-label>Título</mat-label>
       <input matInput formControlName="title" />
+      <mat-error *ngIf="form.get('title')?.hasError('required')">
+        Campo obrigatório
+      </mat-error>
+      <mat-error *ngIf="form.get('title')?.hasError('minlength') || form.get('title')?.hasError('maxlength')">
+        Título deve ter entre 5 e 255 caracteres
+      </mat-error>
     </mat-form-field>
 
   <div class="row">
     <mat-form-field appearance="fill">
       <mat-label>Início</mat-label>
       <input matInput type="datetime-local" formControlName="startDateTime" />
+      <mat-error *ngIf="form.get('startDateTime')?.hasError('required')">
+        Campo obrigatório
+      </mat-error>
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label>Fim</mat-label>
       <input matInput type="datetime-local" formControlName="endDateTime" />
+      <mat-error *ngIf="form.get('endDateTime')?.hasError('required')">
+        Campo obrigatório
+      </mat-error>
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label>Data de Associação</mat-label>
       <input matInput type="date" formControlName="membershipDate" />
+      <mat-error *ngIf="form.get('membershipDate')?.hasError('required')">
+        Campo obrigatório
+      </mat-error>
     </mat-form-field>
   </div>
 

--- a/src/app/edition/edition-form-dialog.ts
+++ b/src/app/edition/edition-form-dialog.ts
@@ -1,6 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -37,10 +37,13 @@ export class EditionFormDialogComponent {
   ) {
     const e = data.edition;
     this.form = this.fb.group({
-      title: [e?.title || ''],
-      startDateTime: [e?.startDateTime || ''],
-      endDateTime: [e?.endDateTime || ''],
-      membershipDate: [e?.membershipDate || ''],
+      title: [
+        e?.title || '',
+        [Validators.required, Validators.minLength(5), Validators.maxLength(255)]
+      ],
+      startDateTime: [e?.startDateTime || '', Validators.required],
+      endDateTime: [e?.endDateTime || '', Validators.required],
+      membershipDate: [e?.membershipDate || '', Validators.required],
       bornFrom: [e?.bornFrom || ''],
       bornUntil: [e?.bornUntil || ''],
       linkExpirationDate: [e?.linkExpirationDate || ''],
@@ -58,6 +61,8 @@ export class EditionFormDialogComponent {
   save() {
     if (this.form.valid) {
       this.dialogRef.close(this.form.value);
+    } else {
+      this.form.markAllAsTouched();
     }
   }
 }


### PR DESCRIPTION
## Summary
- enforce required fields in `EditionFormDialogComponent`
- show validation errors in dialog

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfe8346f8832f9cc78591c0c8c6d7