### PR TITLE
Adiciona validações de data aos formulários

### DIFF
--- a/src/app/edition/edition-form-dialog.html
+++ b/src/app/edition/edition-form-dialog.html
@@ -19,6 +19,9 @@
       <mat-error *ngIf="form.get('startDateTime')?.hasError('required')">
         Campo obrigatório
       </mat-error>
+      <mat-error *ngIf="form.hasError('startAfterEnd')">
+        Data de início deve ser anterior à data final
+      </mat-error>
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label>Fim</mat-label>
@@ -44,6 +47,9 @@
     <mat-form-field appearance="fill">
       <mat-label>Nascidos Até</mat-label>
       <input matInput type="date" formControlName="bornUntil" />
+      <mat-error *ngIf="form.hasError('bornRangeInvalid')">
+        Data inicial de nascimento deve ser anterior ou igual à data final
+      </mat-error>
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label>Expiração do Link</mat-label>

--- a/src/app/edition/edition-form-dialog.ts
+++ b/src/app/edition/edition-form-dialog.ts
@@ -1,6 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -10,6 +10,24 @@ import { CKEditorModule } from '@ckeditor/ckeditor5-angular';
 // @ts-ignore
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import { EditionDto } from './edition-api';
+
+const startBeforeEndValidator: ValidatorFn = (group: AbstractControl): ValidationErrors | null => {
+  const start = group.get('startDateTime')?.value;
+  const end = group.get('endDateTime')?.value;
+  if (start && end && new Date(start) > new Date(end)) {
+    return { startAfterEnd: true };
+  }
+  return null;
+};
+
+const bornRangeValidator: ValidatorFn = (group: AbstractControl): ValidationErrors | null => {
+  const from = group.get('bornFrom')?.value;
+  const until = group.get('bornUntil')?.value;
+  if (from && until && new Date(from) > new Date(until)) {
+    return { bornRangeInvalid: true };
+  }
+  return null;
+};
 
 @Component({
   selector: 'app-edition-form-dialog',
@@ -52,7 +70,7 @@ export class EditionFormDialogComponent {
       description: [e?.description || ''],
       email: [e?.email || ''],
       currentEdition: [e?.currentEdition || false]
-    });
+    }, { validators: [startBeforeEndValidator, bornRangeValidator] });
   }
 
   cancel() {


### PR DESCRIPTION
## Summary
- adicionar validação cruzada de datas em `EditionFormDialog`
- exibir mensagens de erro quando datas forem inválidas

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(falhou: Chrome não disponível)*

------
https://chatgpt.com/codex/tasks/task_e_684e0c77dda4832fb3fe7032ff0df52a