### PR TITLE
Fix date validation messages

### DIFF
--- a/src/app/edition/edition-form-dialog.html
+++ b/src/app/edition/edition-form-dialog.html
@@ -15,7 +15,7 @@
   <div class="row">
     <mat-form-field appearance="fill">
       <mat-label>Início</mat-label>
-      <input matInput type="datetime-local" formControlName="startDateTime" />
+      <input matInput type="datetime-local" formControlName="startDateTime" [errorStateMatcher]="startEndMatcher" />
       <mat-error *ngIf="form.get('startDateTime')?.hasError('required')">
         Campo obrigatório
       </mat-error>
@@ -25,7 +25,7 @@
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label>Fim</mat-label>
-      <input matInput type="datetime-local" formControlName="endDateTime" />
+      <input matInput type="datetime-local" formControlName="endDateTime" [errorStateMatcher]="startEndMatcher" />
       <mat-error *ngIf="form.get('endDateTime')?.hasError('required')">
         Campo obrigatório
       </mat-error>
@@ -42,11 +42,11 @@
   <div class="row">
     <mat-form-field appearance="fill">
       <mat-label>Nascidos De</mat-label>
-      <input matInput type="date" formControlName="bornFrom" />
+      <input matInput type="date" formControlName="bornFrom" [errorStateMatcher]="bornRangeMatcher" />
     </mat-form-field>
     <mat-form-field appearance="fill">
       <mat-label>Nascidos Até</mat-label>
-      <input matInput type="date" formControlName="bornUntil" />
+      <input matInput type="date" formControlName="bornUntil" [errorStateMatcher]="bornRangeMatcher" />
       <mat-error *ngIf="form.hasError('bornRangeInvalid')">
         Data inicial de nascimento deve ser anterior ou igual à data final
       </mat-error>

--- a/src/app/edition/edition-form-dialog.ts
+++ b/src/app/edition/edition-form-dialog.ts
@@ -1,11 +1,23 @@
 import { Component, Inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { AbstractControl, FormBuilder, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import {
+  AbstractControl,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  FormGroupDirective,
+  ReactiveFormsModule,
+  NgForm,
+  ValidationErrors,
+  ValidatorFn,
+  Validators
+} from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatButtonModule } from '@angular/material/button';
+import { ErrorStateMatcher } from '@angular/material/core';
 import { CKEditorModule } from '@ckeditor/ckeditor5-angular';
 // @ts-ignore
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
@@ -29,6 +41,17 @@ const bornRangeValidator: ValidatorFn = (group: AbstractControl): ValidationErro
   return null;
 };
 
+class CrossFieldErrorMatcher implements ErrorStateMatcher {
+  constructor(private errorKey: string) {}
+
+  isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
+    const invalidCtrl = !!(control && control.invalid && control.touched);
+    const parent = control?.parent;
+    const invalidParent = !!(parent && parent.hasError(this.errorKey) && parent.touched);
+    return invalidCtrl || invalidParent;
+  }
+}
+
 @Component({
   selector: 'app-edition-form-dialog',
   standalone: true,
@@ -48,6 +71,8 @@ const bornRangeValidator: ValidatorFn = (group: AbstractControl): ValidationErro
 export class EditionFormDialogComponent {
   form: FormGroup;
   Editor: any = ClassicEditor;
+  startEndMatcher = new CrossFieldErrorMatcher('startAfterEnd');
+  bornRangeMatcher = new CrossFieldErrorMatcher('bornRangeInvalid');
 
   constructor(
     private fb: FormBuilder,


### PR DESCRIPTION
## Summary
- show invalid date errors using custom ErrorStateMatcher
- use matcher on start/end and birth date fields

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npx ng lint` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_684e10c520e8832fb2c1d90cbd142f69