### PR TITLE
Implement basic frontend logging

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,16 +1,17 @@
 import { ApplicationConfig, LOCALE_ID, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app.routes';
+import { httpLogInterceptor } from './http-log.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([httpLogInterceptor])),
     provideAnimations(),
     { provide: LOCALE_ID, useValue: 'pt-BR' }
   ]

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { LoggingService } from './logging.service';
 import { RouterOutlet } from '@angular/router';
 
 @Component({
@@ -9,4 +10,7 @@ import { RouterOutlet } from '@angular/router';
 })
 export class App {
   protected title = 'jogosfenaefrontend';
+  constructor(private logger: LoggingService) {
+    this.logger.log('app init');
+  }
 }

--- a/src/app/edition/edition-form-dialog.ts
+++ b/src/app/edition/edition-form-dialog.ts
@@ -22,6 +22,7 @@ import { CKEditorModule } from '@ckeditor/ckeditor5-angular';
 // @ts-ignore
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import { EditionDto } from './edition-api';
+import { LoggingService } from '../logging.service';
 
 const startBeforeEndValidator: ValidatorFn = (group: AbstractControl): ValidationErrors | null => {
   const start = group.get('startDateTime')?.value;
@@ -77,7 +78,8 @@ export class EditionFormDialogComponent {
   constructor(
     private fb: FormBuilder,
     private dialogRef: MatDialogRef<EditionFormDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: { edition?: EditionDto }
+    @Inject(MAT_DIALOG_DATA) public data: { edition?: EditionDto },
+    private logger: LoggingService
   ) {
     this.form = this.fb.group(
       {
@@ -102,11 +104,13 @@ export class EditionFormDialogComponent {
   }
 
   cancel() {
+    this.logger.log('cancel edition dialog');
     this.dialogRef.close();
   }
 
   save() {
     if (this.form.valid) {
+      this.logger.log('save edition dialog', this.form.value);
       this.dialogRef.close(this.form.value);
     } else {
       this.form.markAllAsTouched();

--- a/src/app/edition/edition.ts
+++ b/src/app/edition/edition.ts
@@ -7,6 +7,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { EditionFormDialogComponent } from './edition-form-dialog';
 import { EditionApi, EditionDto } from './edition-api';
+import { LoggingService } from '../logging.service';
 
 @Component({
   selector: 'app-edition',
@@ -25,13 +26,15 @@ import { EditionApi, EditionDto } from './edition-api';
 export class EditionComponent implements OnInit {
   editions: EditionDto[] = [];
   displayedColumns = ['title', 'start', 'end', 'actions'];
-  constructor(private api: EditionApi, private dialog: MatDialog) {}
+  constructor(private api: EditionApi, private dialog: MatDialog, private logger: LoggingService) {}
 
   ngOnInit() {
+    this.logger.log('edition component init');
     this.load();
   }
 
   load() {
+    this.logger.log('list editions');
     this.api.list().subscribe(data => (this.editions = data));
   }
 
@@ -41,6 +44,7 @@ export class EditionComponent implements OnInit {
     });
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
+        this.logger.log('create edition', result);
         this.api.create(result).subscribe(() => this.load());
       }
     });
@@ -52,6 +56,7 @@ export class EditionComponent implements OnInit {
     });
     dialogRef.afterClosed().subscribe(result => {
       if (result && item.id != null) {
+        this.logger.log('update edition', { id: item.id, ...result });
         this.api.update(item.id, result).subscribe(() => this.load());
       }
     });
@@ -60,6 +65,7 @@ export class EditionComponent implements OnInit {
 
   delete(item: EditionDto) {
     if (item.id != null && confirm('Excluir esta edição?')) {
+      this.logger.log('delete edition', { id: item.id });
       this.api.delete(item.id).subscribe(() => this.load());
     }
   }

--- a/src/app/http-log.interceptor.ts
+++ b/src/app/http-log.interceptor.ts
@@ -1,0 +1,19 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { tap } from 'rxjs';
+import { LoggingService } from './logging.service';
+
+export const httpLogInterceptor: HttpInterceptorFn = (req, next) => {
+  const logger = inject(LoggingService);
+  logger.log('HTTP request', { method: req.method, url: req.urlWithParams });
+  return next(req).pipe(
+    tap({
+      next: event => {
+        logger.log('HTTP response', { url: req.urlWithParams });
+      },
+      error: error => {
+        logger.log('HTTP error', { url: req.urlWithParams, error });
+      }
+    })
+  );
+};

--- a/src/app/logging.service.ts
+++ b/src/app/logging.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, Inject } from '@angular/core';
+import { Router, Event } from '@angular/router';
+import { DOCUMENT } from '@angular/common';
+
+@Injectable({ providedIn: 'root' })
+export class LoggingService {
+  constructor(@Inject(DOCUMENT) document: Document, router: Router) {
+    router.events.subscribe((event: Event) => {
+      this.log('RouterEvent', event);
+    });
+    document.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement;
+      const info = target && target.tagName ? `${target.tagName.toLowerCase()}` : '';
+      this.log('Click', { target: info });
+    });
+  }
+
+  log(action: string, data?: unknown) {
+    // eslint-disable-next-line no-console
+    console.log('[LOG]', action, data);
+  }
+}


### PR DESCRIPTION
## Summary
- add `LoggingService` for global router and click event capture
- hook `httpLogInterceptor` to log all HTTP traffic
- integrate logging with `EditionComponent` and its form dialog
- inject logger in `App` component and boot via app config

## Testing
- `npm test` *(fails: ng not found)*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: cannot find module '@angular/core')*

------
https://chatgpt.com/codex/tasks/task_e_684e18e54fc8832f92b409175ed67d89