### PR TITLE
Improve delete confirmation dialog

### DIFF
--- a/src/app/confirm-dialog.css
+++ b/src/app/confirm-dialog.css
@@ -1,0 +1,5 @@
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/src/app/confirm-dialog.html
+++ b/src/app/confirm-dialog.html
@@ -1,0 +1,9 @@
+<h2 mat-dialog-title>{{ data.message }}</h2>
+<div mat-dialog-actions align="end" class="actions">
+  <button mat-raised-button color="warn" (click)="confirm()">
+    {{ data.confirmText || 'Excluir' }}
+  </button>
+  <button mat-button (click)="cancel()">
+    {{ data.cancelText || 'Cancelar' }}
+  </button>
+</div>

--- a/src/app/confirm-dialog.ts
+++ b/src/app/confirm-dialog.ts
@@ -1,0 +1,32 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+export interface ConfirmDialogData {
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+@Component({
+  selector: 'app-confirm-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './confirm-dialog.html',
+  styleUrls: ['./confirm-dialog.css']
+})
+export class ConfirmDialogComponent {
+  constructor(
+    private dialogRef: MatDialogRef<ConfirmDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: ConfirmDialogData
+  ) {}
+
+  confirm() {
+    this.dialogRef.close(true);
+  }
+
+  cancel() {
+    this.dialogRef.close(false);
+  }
+}

--- a/src/app/edition/edition.ts
+++ b/src/app/edition/edition.ts
@@ -5,6 +5,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
+import { ConfirmDialogComponent } from '../confirm-dialog';
 import { EditionFormDialogComponent } from './edition-form-dialog';
 import { EditionApi, EditionDto } from './edition-api';
 import { LoggingService } from '../logging.service';
@@ -64,9 +65,16 @@ export class EditionComponent implements OnInit {
 
 
   delete(item: EditionDto) {
-    if (item.id != null && confirm('Excluir esta edição?')) {
-      this.logger.log('delete edition', { id: item.id });
-      this.api.delete(item.id).subscribe(() => this.load());
+    if (item.id != null) {
+      const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+        data: { message: 'Excluir esta edição?' }
+      });
+      dialogRef.afterClosed().subscribe(result => {
+        if (result) {
+          this.logger.log('delete edition', { id: item.id });
+          this.api.delete(item.id!).subscribe(() => this.load());
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- add generic Material confirm dialog component
- trigger confirm dialog when deleting an edition

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_684e278ea11c832fa9a9fa1082bc8830