### PR TITLE
Add home landing page with navigation

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,8 +1,9 @@
 import { Routes } from '@angular/router';
 import { EditionComponent } from './edition/edition';
+import { HomeComponent } from './home/home';
 
 export const routes: Routes = [
   { path: 'edition', component: EditionComponent },
-  { path: '', pathMatch: 'full', redirectTo: 'edition' },
-  { path: '**', redirectTo: 'edition' }
+  { path: '', component: HomeComponent, pathMatch: 'full' },
+  { path: '**', redirectTo: '' }
 ];

--- a/src/app/home/home.css
+++ b/src/app/home/home.css
@@ -1,0 +1,21 @@
+.hero {
+  height: calc(100vh - 64px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem;
+  gap: 1.5rem;
+  background: linear-gradient(45deg, #e3f2fd, #bbdefb);
+}
+
+h1 {
+  font-size: 3rem;
+  margin: 0;
+}
+
+p {
+  font-size: 1.25rem;
+  margin: 0;
+}

--- a/src/app/home/home.html
+++ b/src/app/home/home.html
@@ -1,0 +1,6 @@
+<mat-toolbar color="primary">Jogos FENAE</mat-toolbar>
+<div class="hero">
+  <h1>Bem-vindo ao Jogos FENAE</h1>
+  <p>Gerencie facilmente as edições do evento.</p>
+  <button mat-raised-button color="accent" routerLink="/edition">Cadastrar Edição</button>
+</div>

--- a/src/app/home/home.ts
+++ b/src/app/home/home.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  imports: [CommonModule, MatToolbarModule, MatButtonModule, RouterModule],
+  templateUrl: './home.html',
+  styleUrls: ['./home.css']
+})
+export class HomeComponent {}


### PR DESCRIPTION
## Summary
- create HomeComponent with basic hero layout
- update routes to show HomeComponent at `/`

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run build` *(fails: Inlining of fonts failed: status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_684e2d4bcd08832facc3bccff33dd6a2