### PR TITLE
Add home navigation on edition screen

### DIFF
--- a/src/app/edition/edition.css
+++ b/src/app/edition/edition.css
@@ -22,3 +22,7 @@
   gap: 0.5rem;
   margin-top: 1rem;
 }
+
+.toolbar-title {
+  margin-left: 0.5rem;
+}

--- a/src/app/edition/edition.html
+++ b/src/app/edition/edition.html
@@ -1,4 +1,9 @@
-<mat-toolbar color="primary">Edições</mat-toolbar>
+<mat-toolbar color="primary">
+  <button mat-icon-button routerLink="/" aria-label="Voltar para página inicial">
+    <span class="material-icons">home</span>
+  </button>
+  <span class="toolbar-title">Edições</span>
+</mat-toolbar>
 
 <div class="container">
   <div class="actions">

--- a/src/app/edition/edition.ts
+++ b/src/app/edition/edition.ts
@@ -5,6 +5,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
+import { RouterModule } from '@angular/router';
 import { ConfirmDialogComponent } from '../confirm-dialog';
 import { EditionFormDialogComponent } from './edition-form-dialog';
 import { EditionApi, EditionDto } from './edition-api';
@@ -19,7 +20,8 @@ import { LoggingService } from '../logging.service';
     MatButtonModule,
     MatTableModule,
     MatIconModule,
-    MatDialogModule
+    MatDialogModule,
+    RouterModule
   ],
   templateUrl: './edition.html',
   styleUrls: ['./edition.css']


### PR DESCRIPTION
## Summary
- add RouterModule to edition component
- show a home icon button in toolbar on /edition
- minor CSS tweak

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run build` *(fails: Inlining fonts 403)*

------
https://chatgpt.com/codex/tasks/task_e_684e311478a8832f88ad9827e0ab2561