### PR TITLE
Add APCEF company form

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,9 +1,11 @@
 import { Routes } from '@angular/router';
 import { EditionComponent } from './edition/edition';
+import { CompanyComponent } from './company/company';
 import { HomeComponent } from './home/home';
 
 export const routes: Routes = [
   { path: 'edition', component: EditionComponent },
+  { path: 'company', component: CompanyComponent },
   { path: '', component: HomeComponent, pathMatch: 'full' },
   { path: '**', redirectTo: '' }
 ];

--- a/src/app/company/company-api.ts
+++ b/src/app/company/company-api.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { EditionDto } from '../edition/edition-api';
+
+export interface CompanyDto {
+  id?: string;
+  createdDateTime: string;
+  updatedDateTime: string;
+  title: string;
+  participantNumber: number;
+  presidentNumber: number;
+  sportsDirectorNumber: number;
+  athleteNumber: number;
+  parathleteNumber: number;
+  technicalNumber: number;
+  edition?: EditionDto;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CompanyApi {
+  private baseUrl = `${environment.apiBaseUrl}/rest/v1/company`;
+
+  constructor(private http: HttpClient) {}
+
+  list(): Observable<CompanyDto[]> {
+    return this.http.get<CompanyDto[]>(this.baseUrl);
+  }
+
+  get(id: string): Observable<CompanyDto> {
+    return this.http.get<CompanyDto>(`${this.baseUrl}/${id}`);
+  }
+
+  create(editionId: string, company: CompanyDto): Observable<CompanyDto> {
+    return this.http.post<CompanyDto>(`${this.baseUrl}?editionId=${editionId}`, company);
+  }
+
+  update(id: string, company: CompanyDto): Observable<CompanyDto> {
+    return this.http.put<CompanyDto>(`${this.baseUrl}/${id}`, company);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+}

--- a/src/app/company/company-form-dialog.css
+++ b/src/app/company/company-form-dialog.css
@@ -1,0 +1,18 @@
+.dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.full-width {
+  width: 100%;
+}
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/src/app/company/company-form-dialog.html
+++ b/src/app/company/company-form-dialog.html
@@ -1,0 +1,51 @@
+<h2 mat-dialog-title>{{ data.company ? 'Editar Apcef' : 'Nova Apcef' }}</h2>
+<form [formGroup]="form" class="dialog-form" (ngSubmit)="save()">
+  <div mat-dialog-content>
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Título</mat-label>
+      <input matInput formControlName="title" />
+      <mat-error *ngIf="form.get('title')?.hasError('required')">
+        Campo obrigatório
+      </mat-error>
+    </mat-form-field>
+
+    <div class="row">
+      <mat-form-field appearance="fill">
+        <mat-label>Participantes</mat-label>
+        <input matInput type="number" formControlName="participantNumber" />
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Presidentes</mat-label>
+        <input matInput type="number" formControlName="presidentNumber" />
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Diretores de Esporte</mat-label>
+        <input matInput type="number" formControlName="sportsDirectorNumber" />
+      </mat-form-field>
+    </div>
+
+    <div class="row">
+      <mat-form-field appearance="fill">
+        <mat-label>Atletas</mat-label>
+        <input matInput type="number" formControlName="athleteNumber" />
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Paratletas</mat-label>
+        <input matInput type="number" formControlName="parathleteNumber" />
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Técnicos</mat-label>
+        <input matInput type="number" formControlName="technicalNumber" />
+      </mat-form-field>
+    </div>
+
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>ID da Edição</mat-label>
+      <input matInput formControlName="editionId" />
+    </mat-form-field>
+  </div>
+  <div mat-dialog-actions align="end" class="actions">
+    <button mat-raised-button color="primary" type="submit">Salvar</button>
+    <button mat-button type="button" (click)="cancel()">Cancelar</button>
+  </div>
+</form>

--- a/src/app/company/company-form-dialog.ts
+++ b/src/app/company/company-form-dialog.ts
@@ -1,0 +1,63 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { CompanyDto } from './company-api';
+import { LoggingService } from '../logging.service';
+
+@Component({
+  selector: 'app-company-form-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule
+  ],
+  templateUrl: './company-form-dialog.html',
+  styleUrls: ['./company-form-dialog.css']
+})
+export class CompanyFormDialogComponent {
+  form: FormGroup;
+
+  constructor(
+    private fb: FormBuilder,
+    private dialogRef: MatDialogRef<CompanyFormDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { company?: CompanyDto },
+    private logger: LoggingService
+  ) {
+    this.form = this.fb.group({
+      title: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(255)]],
+      participantNumber: [0, Validators.required],
+      presidentNumber: [0, Validators.required],
+      sportsDirectorNumber: [0, Validators.required],
+      athleteNumber: [0, Validators.required],
+      parathleteNumber: [0, Validators.required],
+      technicalNumber: [0, Validators.required],
+      editionId: ['', Validators.required]
+    });
+
+    if (data.company) {
+      this.form.patchValue({ ...data.company, editionId: data.company.edition?.id });
+    }
+  }
+
+  cancel() {
+    this.logger.log('cancel company dialog');
+    this.dialogRef.close();
+  }
+
+  save() {
+    if (this.form.valid) {
+      this.logger.log('save company dialog', this.form.value);
+      this.dialogRef.close(this.form.value);
+    } else {
+      this.form.markAllAsTouched();
+    }
+  }
+}

--- a/src/app/company/company.css
+++ b/src/app/company/company.css
@@ -1,0 +1,28 @@
+.container {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.table {
+  width: 100%;
+  overflow: auto;
+}
+
+.form-card {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.toolbar-title {
+  margin-left: 0.5rem;
+}

--- a/src/app/company/company.html
+++ b/src/app/company/company.html
@@ -1,0 +1,39 @@
+<mat-toolbar color="primary">
+  <button mat-icon-button routerLink="/" aria-label="Voltar para página inicial">
+    <span class="material-icons">home</span>
+  </button>
+  <span class="toolbar-title">APCEFs</span>
+</mat-toolbar>
+
+<div class="container">
+  <div class="actions">
+    <button mat-raised-button color="primary" (click)="add()">Adicionar</button>
+  </div>
+
+  <table mat-table [dataSource]="companies" class="mat-elevation-z1 table">
+    <ng-container matColumnDef="title">
+      <th mat-header-cell *matHeaderCellDef>Título</th>
+      <td mat-cell *matCellDef="let c">{{ c.title }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="edition">
+      <th mat-header-cell *matHeaderCellDef>Edição</th>
+      <td mat-cell *matCellDef="let c">{{ c.edition?.title }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef>Ações</th>
+      <td mat-cell *matCellDef="let c">
+        <button mat-icon-button color="primary" (click)="edit(c)">
+          <span class="material-icons">edit</span>
+        </button>
+        <button mat-icon-button color="warn" (click)="delete(c)">
+          <span class="material-icons">delete</span>
+        </button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+  </table>
+</div>

--- a/src/app/company/company.ts
+++ b/src/app/company/company.ts
@@ -1,0 +1,76 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTableModule } from '@angular/material/table';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialogModule, MatDialog } from '@angular/material/dialog';
+import { RouterModule } from '@angular/router';
+import { ConfirmDialogComponent } from '../confirm-dialog';
+import { CompanyFormDialogComponent } from './company-form-dialog';
+import { CompanyApi, CompanyDto } from './company-api';
+import { LoggingService } from '../logging.service';
+
+@Component({
+  selector: 'app-company',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatToolbarModule,
+    MatButtonModule,
+    MatTableModule,
+    MatIconModule,
+    MatDialogModule,
+    RouterModule
+  ],
+  templateUrl: './company.html',
+  styleUrls: ['./company.css']
+})
+export class CompanyComponent implements OnInit {
+  companies: CompanyDto[] = [];
+  displayedColumns = ['title', 'edition', 'actions'];
+
+  constructor(private api: CompanyApi, private dialog: MatDialog, private logger: LoggingService) {}
+
+  ngOnInit() {
+    this.logger.log('company component init');
+    this.load();
+  }
+
+  load() {
+    this.logger.log('list companies');
+    this.api.list().subscribe(data => (this.companies = data));
+  }
+
+  add() {
+    const dialogRef = this.dialog.open(CompanyFormDialogComponent, { data: {} });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.logger.log('create company', result);
+        this.api.create(result.editionId, result).subscribe(() => this.load());
+      }
+    });
+  }
+
+  edit(item: CompanyDto) {
+    const dialogRef = this.dialog.open(CompanyFormDialogComponent, { data: { company: item } });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result && item.id) {
+        this.logger.log('update company', { id: item.id, ...result });
+        this.api.update(item.id, result).subscribe(() => this.load());
+      }
+    });
+  }
+
+  delete(item: CompanyDto) {
+    if (item.id) {
+      const dialogRef = this.dialog.open(ConfirmDialogComponent, { data: { message: 'Excluir esta APCEF?' } });
+      dialogRef.afterClosed().subscribe(result => {
+        if (result) {
+          this.logger.log('delete company', { id: item.id });
+          this.api.delete(item.id).subscribe(() => this.load());
+        }
+      });
+    }
+  }
+}

--- a/src/app/home/home.html
+++ b/src/app/home/home.html
@@ -3,4 +3,5 @@
   <h1>Bem-vindo ao Jogos Fenae e Apcefs</h1>
   <p>Gerencie facilmente as edições do evento.</p>
   <button mat-raised-button color="accent" routerLink="/edition">Cadastrar Edição</button>
+  <button mat-raised-button color="primary" routerLink="/company">Cadastrar APCEF</button>
 </div>


### PR DESCRIPTION
## Summary
- add APCEF (company) management components
- route `/company` to manage APCEFs
- show "Cadastrar APCEF" button on home page

## Testing
- `npm test --silent` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f466c372c832fa61440ff13331f66