### PR TITLE
Add navigation from edition to company

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { HomeComponent } from './home/home';
 
 export const routes: Routes = [
   { path: 'edition', component: EditionComponent },
+  { path: 'company/:editionId', component: CompanyComponent },
   { path: 'company', component: CompanyComponent },
   { path: '', component: HomeComponent, pathMatch: 'full' },
   { path: '**', redirectTo: '' }

--- a/src/app/company/company-api.ts
+++ b/src/app/company/company-api.ts
@@ -30,6 +30,10 @@ export class CompanyApi {
     return this.http.get<CompanyDto[]>(this.baseUrl);
   }
 
+  listByEdition(editionId: string): Observable<CompanyDto[]> {
+    return this.http.get<CompanyDto[]>(`${this.baseUrl}?editionId=${editionId}`);
+  }
+
   get(id: string): Observable<CompanyDto> {
     return this.http.get<CompanyDto>(`${this.baseUrl}/${id}`);
   }

--- a/src/app/company/company-form-dialog.html
+++ b/src/app/company/company-form-dialog.html
@@ -41,7 +41,7 @@
 
     <mat-form-field appearance="fill" class="full-width">
       <mat-label>ID da Edição</mat-label>
-      <input matInput formControlName="editionId" />
+      <input matInput formControlName="editionId" [disabled]="data.editionId" />
     </mat-form-field>
   </div>
   <div mat-dialog-actions align="end" class="actions">

--- a/src/app/company/company-form-dialog.ts
+++ b/src/app/company/company-form-dialog.ts
@@ -28,7 +28,8 @@ export class CompanyFormDialogComponent {
   constructor(
     private fb: FormBuilder,
     private dialogRef: MatDialogRef<CompanyFormDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: { company?: CompanyDto },
+    @Inject(MAT_DIALOG_DATA)
+    public data: { company?: CompanyDto; editionId?: string },
     private logger: LoggingService
   ) {
     this.form = this.fb.group({
@@ -44,6 +45,9 @@ export class CompanyFormDialogComponent {
 
     if (data.company) {
       this.form.patchValue({ ...data.company, editionId: data.company.edition?.id });
+    }
+    if (data.editionId) {
+      this.form.patchValue({ editionId: data.editionId });
     }
   }
 

--- a/src/app/edition/edition.html
+++ b/src/app/edition/edition.html
@@ -32,6 +32,14 @@
         <button mat-icon-button color="primary" (click)="edit(e)">
           <span class="material-icons">edit</span>
         </button>
+        <button
+          mat-icon-button
+          color="accent"
+          [routerLink]="['/company', e.id]"
+          aria-label="APCEFs desta edição"
+        >
+          <span class="material-icons">business</span>
+        </button>
         <button mat-icon-button color="warn" (click)="delete(e)">
           <span class="material-icons">delete</span>
         </button>


### PR DESCRIPTION
## Summary
- add route `company/:editionId` to open companies filtered by edition
- pass editionId from edition list via new button
- update CompanyComponent to load companies by edition and prefill form
- support editionId parameter in CompanyFormDialog
- add listByEdition method in CompanyApi

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4c4454b0832fa8d69a9aae9715e1