### PR TITLE
Fix editionId disable boolean

### DIFF
--- a/src/app/company/company-form-dialog.html
+++ b/src/app/company/company-form-dialog.html
@@ -41,7 +41,7 @@
 
     <mat-form-field appearance="fill" class="full-width">
       <mat-label>ID da Edição</mat-label>
-      <input matInput formControlName="editionId" [disabled]="data.editionId" />
+      <input matInput formControlName="editionId" [disabled]="!!data.editionId" />
     </mat-form-field>
   </div>
   <div mat-dialog-actions align="end" class="actions">


### PR DESCRIPTION
## Summary
- fix `editionId` disabled boolean expression

## Testing
- `npx ng test --watch=false` *(fails: could not determine executable to run)*
- `npm install` *(fails: network access issues)*

------
https://chatgpt.com/codex/tasks/task_e_684f4d492ec0832fa74f30d38464680c