### PR TITLE
Hide edition field and adjust navigation

### DIFF
--- a/src/app/company/company-form-dialog.html
+++ b/src/app/company/company-form-dialog.html
@@ -38,13 +38,9 @@
         <input matInput type="number" formControlName="technicalNumber" />
       </mat-form-field>
     </div>
-
-    <mat-form-field appearance="fill" class="full-width">
-      <mat-label>ID da Edição</mat-label>
-      <input matInput formControlName="editionId" [disabled]="!!data.editionId" />
-    </mat-form-field>
-  </div>
-  <div mat-dialog-actions align="end" class="actions">
+      <input type="hidden" formControlName="editionId" />
+    </div>
+    <div mat-dialog-actions align="end" class="actions">
     <button mat-raised-button color="primary" type="submit">Salvar</button>
     <button mat-button type="button" (click)="cancel()">Cancelar</button>
   </div>

--- a/src/app/company/company.html
+++ b/src/app/company/company.html
@@ -2,6 +2,7 @@
   <button mat-icon-button routerLink="/" aria-label="Voltar para página inicial">
     <span class="material-icons">home</span>
   </button>
+  <button mat-button routerLink="/edition">Voltar</button>
   <span class="toolbar-title">APCEFs</span>
 </mat-toolbar>
 

--- a/src/app/home/home.html
+++ b/src/app/home/home.html
@@ -3,5 +3,4 @@
   <h1>Bem-vindo ao Jogos Fenae e Apcefs</h1>
   <p>Gerencie facilmente as edições do evento.</p>
   <button mat-raised-button color="accent" routerLink="/edition">Cadastrar Edição</button>
-  <button mat-raised-button color="primary" routerLink="/company">Cadastrar APCEF</button>
 </div>


### PR DESCRIPTION
## Summary
- remove APCEF shortcut from the home page
- hide editionId input in company dialog
- add a **Voltar** button linking back to editions

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5080b134832f9b2c1088fb48c2ab