### PR TITLE
Fix company list not resetting

### DIFF
--- a/src/app/company/company.ts
+++ b/src/app/company/company.ts
@@ -49,6 +49,8 @@ export class CompanyComponent implements OnInit {
 
   load() {
     this.logger.log('list companies');
+    // Clear the current list so old data is not displayed if the request fails
+    this.companies = [];
     if (this.editionId) {
       this.api
         .listByEdition(this.editionId)


### PR DESCRIPTION
## Summary
- clear company list while loading data so previous edition data doesn't linger

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684f58f1f69c832f8a9a54c694552579