### PR TITLE
Fix filtering of APCEFs by edition

### DIFF
--- a/src/app/company/company.ts
+++ b/src/app/company/company.ts
@@ -54,7 +54,10 @@ export class CompanyComponent implements OnInit {
     if (this.editionId) {
       this.api
         .listByEdition(this.editionId)
-        .subscribe(data => (this.companies = data));
+        .subscribe(
+          data =>
+            (this.companies = data.filter(c => c.edition?.id === this.editionId))
+        );
     } else {
       this.api.list().subscribe(data => (this.companies = data));
     }


### PR DESCRIPTION
## Summary
- ensure the APCEF list page filters companies by the selected edition

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5c28bec0832fa651ab561662e899