### PR TITLE
Fix duplicate APCEF creation message

### DIFF
--- a/src/app/company/company.ts
+++ b/src/app/company/company.ts
@@ -71,7 +71,10 @@ export class CompanyComponent implements OnInit {
       if (result) {
         this.logger.log('create company', result);
         const editionId = this.editionId ?? result.editionId;
-        this.api.create(editionId, result).subscribe(() => this.load());
+        this.api.create(editionId, result).subscribe({
+          next: () => this.load(),
+          error: err => alert(err.error?.message || 'Erro ao criar APCEF')
+        });
       }
     });
   }
@@ -81,7 +84,10 @@ export class CompanyComponent implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result && item.id) {
         this.logger.log('update company', { id: item.id, ...result });
-        this.api.update(item.id, result).subscribe(() => this.load());
+        this.api.update(item.id, result).subscribe({
+          next: () => this.load(),
+          error: err => alert(err.error?.message || 'Erro ao atualizar APCEF')
+        });
       }
     });
   }


### PR DESCRIPTION
## Summary
- handle errors when creating or updating APCEF records so the user sees backend messages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5e9fee94832fb7a2042df1a6baaf