### PR TITLE
Block title change on APCEF edit

### DIFF
--- a/src/app/company/company-form-dialog.html
+++ b/src/app/company/company-form-dialog.html
@@ -3,7 +3,7 @@
   <div mat-dialog-content>
     <mat-form-field appearance="fill" class="full-width">
       <mat-label>Título</mat-label>
-      <mat-select formControlName="title">
+      <mat-select formControlName="title" [disabled]="data.company">
         <mat-option *ngFor="let option of apcefOptions" [value]="option.value">
           {{ option.label }}
         </mat-option>

--- a/src/app/company/company-form-dialog.ts
+++ b/src/app/company/company-form-dialog.ts
@@ -77,6 +77,7 @@ export class CompanyFormDialogComponent {
 
     if (data.company) {
       this.form.patchValue({ ...data.company, editionId: data.company.edition?.id });
+      this.form.get('title')?.disable();
     }
     if (data.editionId) {
       this.form.patchValue({ editionId: data.editionId });
@@ -90,8 +91,9 @@ export class CompanyFormDialogComponent {
 
   save() {
     if (this.form.valid) {
-      this.logger.log('save company dialog', this.form.value);
-      this.dialogRef.close(this.form.value);
+      const value = this.form.getRawValue();
+      this.logger.log('save company dialog', value);
+      this.dialogRef.close(value);
     } else {
       this.form.markAllAsTouched();
     }


### PR DESCRIPTION
## Summary
- disable the "Título" field on Apcef edit
- keep the value of disabled field when saving the form

## Testing
- `node node_modules/@angular/cli/bin/ng test --browsers=ChromeHeadless --watch=false --no-progress` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_684f5fabeed4832f9460e66e8f0b40d7