### PR TITLE
Replace alert() with dialog

### DIFF
--- a/src/app/company/company.ts
+++ b/src/app/company/company.ts
@@ -8,6 +8,7 @@ import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { RouterModule, ActivatedRoute } from '@angular/router';
 import { ConfirmDialogComponent } from '../confirm-dialog';
 import { CompanyFormDialogComponent } from './company-form-dialog';
+import { MessageDialogComponent } from '../message-dialog/message-dialog';
 import { CompanyApi, CompanyDto } from './company-api';
 import { LoggingService } from '../logging.service';
 
@@ -73,7 +74,11 @@ export class CompanyComponent implements OnInit {
         const editionId = this.editionId ?? result.editionId;
         this.api.create(editionId, result).subscribe({
           next: () => this.load(),
-          error: err => alert(err.error?.message || 'Erro ao criar APCEF')
+          error: err => {
+            const dialogRef = this.dialog.open(MessageDialogComponent, {
+              data: { message: err.error?.message || 'Erro ao criar APCEF' }
+            });
+          }
         });
       }
     });
@@ -86,7 +91,11 @@ export class CompanyComponent implements OnInit {
         this.logger.log('update company', { id: item.id, ...result });
         this.api.update(item.id, result).subscribe({
           next: () => this.load(),
-          error: err => alert(err.error?.message || 'Erro ao atualizar APCEF')
+          error: err => {
+            const dialogRef = this.dialog.open(MessageDialogComponent, {
+              data: { message: err.error?.message || 'Erro ao atualizar APCEF' }
+            });
+          }
         });
       }
     });

--- a/src/app/message-dialog/message-dialog.css
+++ b/src/app/message-dialog/message-dialog.css
@@ -1,0 +1,5 @@
+.actions {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/app/message-dialog/message-dialog.html
+++ b/src/app/message-dialog/message-dialog.html
@@ -1,0 +1,6 @@
+<h2 mat-dialog-title>{{ data.message }}</h2>
+<div mat-dialog-actions align="end" class="actions">
+  <button mat-raised-button color="primary" (click)="close()">
+    {{ data.closeText || 'OK' }}
+  </button>
+</div>

--- a/src/app/message-dialog/message-dialog.ts
+++ b/src/app/message-dialog/message-dialog.ts
@@ -1,0 +1,27 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+export interface MessageDialogData {
+  message: string;
+  closeText?: string;
+}
+
+@Component({
+  selector: 'app-message-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './message-dialog.html',
+  styleUrls: ['./message-dialog.css']
+})
+export class MessageDialogComponent {
+  constructor(
+    private dialogRef: MatDialogRef<MessageDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: MessageDialogData
+  ) {}
+
+  close() {
+    this.dialogRef.close();
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable MessageDialogComponent
- use MessageDialogComponent for API error handling in company component

## Testing
- `npm test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_684f61efbd20832faae3502f6f18f34e