### PR TITLE
Fix form disabled check

### DIFF
--- a/src/app/company/company-form-dialog.html
+++ b/src/app/company/company-form-dialog.html
@@ -3,7 +3,7 @@
   <div mat-dialog-content>
     <mat-form-field appearance="fill" class="full-width">
       <mat-label>Título</mat-label>
-      <mat-select formControlName="title" [disabled]="data.company">
+      <mat-select formControlName="title" [disabled]="!!data.company">
         <mat-option *ngFor="let option of apcefOptions" [value]="option.value">
           {{ option.label }}
         </mat-option>


### PR DESCRIPTION
## Summary
- ensure `data.company` is cast to boolean before passing to `[disabled]` attribute

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f64b28f20832fb2739c759ed479f3