### PR TITLE
Ensure Content-Type header for API POST/PUT

### DIFF
--- a/src/app/company/company-api.ts
+++ b/src/app/company/company-api.ts
@@ -39,11 +39,15 @@ export class CompanyApi {
   }
 
   create(editionId: string, company: CompanyDto): Observable<CompanyDto> {
-    return this.http.post<CompanyDto>(`${this.baseUrl}?editionId=${editionId}`, company);
+    return this.http.post<CompanyDto>(`${this.baseUrl}?editionId=${editionId}`, company, {
+      headers: { 'Content-Type': 'application/json' }
+    });
   }
 
   update(id: string, company: CompanyDto): Observable<CompanyDto> {
-    return this.http.put<CompanyDto>(`${this.baseUrl}/${id}`, company);
+    return this.http.put<CompanyDto>(`${this.baseUrl}/${id}`, company, {
+      headers: { 'Content-Type': 'application/json' }
+    });
   }
 
   delete(id: string): Observable<void> {

--- a/src/app/edition/edition-api.ts
+++ b/src/app/edition/edition-api.ts
@@ -40,11 +40,15 @@ export class EditionApi {
   }
 
   create(edition: EditionDto): Observable<EditionDto> {
-    return this.http.post<EditionDto>(this.baseUrl, edition);
+    return this.http.post<EditionDto>(this.baseUrl, edition, {
+      headers: { 'Content-Type': 'application/json' }
+    });
   }
 
   update(id: number, edition: EditionDto): Observable<EditionDto> {
-    return this.http.put<EditionDto>(`${this.baseUrl}/${id}`, edition);
+    return this.http.put<EditionDto>(`${this.baseUrl}/${id}`, edition, {
+      headers: { 'Content-Type': 'application/json' }
+    });
   }
 
   delete(id: number): Observable<void> {


### PR DESCRIPTION
## Summary
- explicitly set `Content-Type: application/json` when creating or updating editions and companies

## Testing
- `npm test` *(fails: ng executable not found)*
- `npx ng test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_6851bf088a9c832fa99d8e111d803470